### PR TITLE
Add recent posts API endpoint

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -232,8 +232,8 @@ export const NotionPage: React.FC<types.PageProps> = ({
 
   const socialImage = mapImageUrl(
     getPageProperty<string>('Social Image', block, recordMap) ||
-    (block as PageBlock).format?.page_cover ||
-    config.defaultPageCover,
+    config.defaultPageCover ||
+    (block as PageBlock).format?.page_cover,
     block
   )
 

--- a/pages/api/recent-posts.ts
+++ b/pages/api/recent-posts.ts
@@ -1,0 +1,110 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+import { ExtendedRecordMap } from 'notion-types'
+import {
+  getBlockParentPage,
+  getBlockTitle,
+  getPageProperty,
+  idToUuid
+} from 'notion-utils'
+
+import * as config from '@/lib/config'
+import { getSiteMap } from '@/lib/get-site-map'
+import { getSocialImageUrl } from '@/lib/get-social-image-url'
+import { getCanonicalPageUrl } from '@/lib/map-page-url'
+
+type BlogPost = {
+  title: string
+  description: string
+  published: number // unix timestamp
+  url: string
+  authors: string[]
+  coverImage: {
+    url: string
+    width: number
+    height: number
+  }
+}
+
+type Response = {
+  posts: BlogPost[]
+}
+
+/**
+ * This handler exposes recent blog posts as a JSON object for displaying post
+ * previews on the rest of the site.
+ */
+export default async function (req: NextApiRequest, res: NextApiResponse) {
+  const siteMap = await getSiteMap()
+  const ttl = 24 * 60 * 60 // 24 hours
+  const data: Response = {
+    posts: []
+  }
+
+  const limit = 5
+
+  for (const pagePath of Object.keys(siteMap.canonicalPageMap)) {
+    const pageId = siteMap.canonicalPageMap[pagePath]
+    const recordMap = siteMap.pageMap[pageId] as ExtendedRecordMap
+    if (!recordMap) continue
+
+    const keys = Object.keys(recordMap?.block || {})
+    const block = recordMap?.block?.[keys[0]]?.value
+    if (!block) continue
+
+    const parentPage = getBlockParentPage(block, recordMap)
+    const isBlogPost =
+      block.type === 'page' &&
+      block.parent_table === 'collection' &&
+      parentPage?.id === idToUuid(config.rootNotionPageId)
+    if (!isBlogPost) {
+      continue
+    }
+
+    const isPublished = getPageProperty<number>('Published', block, recordMap)
+    if (!isPublished) {
+      continue
+    }
+
+    const title = getBlockTitle(block, recordMap) || config.name
+    const description =
+      getPageProperty<string>('Description', block, recordMap) ||
+      config.description
+    const url = getCanonicalPageUrl(config.site, recordMap)(pageId)
+    const socialImageUrl = getSocialImageUrl(pageId)
+    const authorList =
+      getPageProperty<string>('Authors', block, recordMap) || config.author
+    const published = getPageProperty<number>('Date', block, recordMap)
+
+    // By default, social image URLs have a big title in front. We add an extra
+    // query parameter to signal that we want to use the image as-is.
+    const revisedImageUrl = new URL(socialImageUrl)
+    revisedImageUrl.searchParams.set('text', 'false')
+    const coverImageUrl = revisedImageUrl.toString()
+
+    data.posts.push({
+      title,
+      description,
+      published,
+      coverImage: {
+        url: coverImageUrl,
+        width: 1200,
+        height: 630
+      },
+      url,
+      authors: authorList
+        .split(',')
+        // Remove any uses of the word "and", along with any extra whitespace.
+        .map((s) => s.replace(/\band\b/g, '').trim())
+    })
+  }
+
+  // Sort posts from newest to oldest.
+  data.posts.sort((a, b) => b.published - a.published).slice(0, limit)
+
+  res.setHeader(
+    'Cache-Control',
+    `s-maxage=${ttl}, stale-while-revalidate=${ttl}`
+  )
+  res.status(200).json(data)
+}

--- a/pages/api/social-image.tsx
+++ b/pages/api/social-image.tsx
@@ -38,6 +38,7 @@ export default async function OGImage(req: NextRequest) {
   const pageInfo: NotionPageInfo = await pageInfoRes.json()
   console.log(pageInfo)
 
+  const showText = searchParams.get('text') !== 'false'
   const [interRegularFont, interBoldFont] = await Promise.all([
     interRegularFontP,
     interBoldFontP
@@ -84,76 +85,82 @@ export default async function OGImage(req: NextRequest) {
           />
         )}
 
-        <div
-          style={{
-            position: 'relative',
-            width: 900,
-            height: 465,
-            display: 'flex',
-            flexDirection: 'column',
-            border: '16px solid rgba(0,0,0,0.3)',
-            borderRadius: 8,
-            zIndex: '1'
-          }}
-        >
-          <div
-            style={{
-              width: '100%',
-              height: '100%',
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'space-around',
-              backgroundColor: '#fff',
-              padding: 24,
-              alignItems: 'center',
-              textAlign: 'center'
-            }}
-          >
-            {pageInfo.detail && (
-              <div style={{ fontSize: 32, opacity: 0 }}>{pageInfo.detail}</div>
-            )}
-
+        {showText && (
+          <>
             <div
               style={{
-                fontSize: 70,
-                fontWeight: 700,
-                fontFamily: 'Inter'
+                position: 'relative',
+                width: 900,
+                height: 465,
+                display: 'flex',
+                flexDirection: 'column',
+                border: '16px solid rgba(0,0,0,0.3)',
+                borderRadius: 8,
+                zIndex: '1'
               }}
             >
-              {pageInfo.title}
+              <div
+                style={{
+                  width: '100%',
+                  height: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'space-around',
+                  backgroundColor: '#fff',
+                  padding: 24,
+                  alignItems: 'center',
+                  textAlign: 'center'
+                }}
+              >
+                {pageInfo.detail && (
+                  <div style={{ fontSize: 32, opacity: 0 }}>
+                    {pageInfo.detail}
+                  </div>
+                )}
+
+                <div
+                  style={{
+                    fontSize: 70,
+                    fontWeight: 700,
+                    fontFamily: 'Inter'
+                  }}
+                >
+                  {pageInfo.title}
+                </div>
+
+                {pageInfo.detail && (
+                  <div style={{ fontSize: 32, opacity: 0.6 }}>
+                    {pageInfo.detail}
+                  </div>
+                )}
+              </div>
             </div>
 
-            {pageInfo.detail && (
-              <div style={{ fontSize: 32, opacity: 0.6 }}>
-                {pageInfo.detail}
+            {pageInfo.authorImage && (
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 47,
+                  left: 104,
+                  height: 128,
+                  width: 128,
+                  display: 'flex',
+                  borderRadius: '50%',
+                  border: '4px solid #fff',
+                  zIndex: '5'
+                }}
+              >
+                <img
+                  src={pageInfo.authorImage}
+                  style={{
+                    width: '100%',
+                    height: '100%'
+                    // transform: 'scale(1.04)'
+                  }}
+                />
               </div>
             )}
-          </div>
-        </div>
-
-        {pageInfo.authorImage && (
-          <div
-            style={{
-              position: 'absolute',
-              top: 47,
-              left: 104,
-              height: 128,
-              width: 128,
-              display: 'flex',
-              borderRadius: '50%',
-              border: '4px solid #fff',
-              zIndex: '5'
-            }}
-          >
-            <img
-              src={pageInfo.authorImage}
-              style={{
-                width: '100%',
-                height: '100%'
-                // transform: 'scale(1.04)'
-              }}
-            />
-          </div>
+          </>
         )}
       </div>
     ),

--- a/styles/nline.css
+++ b/styles/nline.css
@@ -39,26 +39,25 @@ body {
   caret-color: var(--fg-color);
 }
 
-::-webkit-scrollbar
-{
+::-webkit-scrollbar {
   width: 5px;
   height: 5px;
-  background-color: #F5F5F5;
+  background-color: #f5f5f5;
   background-color: var(--bg-color-1);
 }
 
-::-webkit-scrollbar-thumb
-{
+::-webkit-scrollbar-thumb {
   border-radius: 10px;
-  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,.3);
+  -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
   background-color: #555;
   border-radius: 10px;
-  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,.3);
+  -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
   background-color: var(--fg-color-1);
 }
 
-::-webkit-scrollbar-track {           
-    background-color: var(--bg-color);
+::-webkit-scrollbar-track {
+  background-color: var(--bg-color);
+}
 
 /* Fix wide TOC */
 .notion-aside {
@@ -82,7 +81,7 @@ body {
   text-overflow: ellipsis;
 }
 
-.notion-header .breadcrumb.active>.title {
+.notion-header .breadcrumb.active > .title {
   overflow: hidden;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
This commit introduces a recent posts API endpoint which returns details about the most recent blog posts for use in throughout the site. This approach is easier to integrate than parsing the RSS feed, and lets us provide additional details which aren't currently included in the RSS feed.